### PR TITLE
Docs: remove OAuth1 from authentication docs and fix OAuth2 bearer auth example

### DIFF
--- a/docs/examples/authentication.md
+++ b/docs/examples/authentication.md
@@ -4,55 +4,22 @@ Although you can access any public data without authentication, you need to auth
 (_but not limited to_) accessing data from a private repository, or give access to a repository.
 Bitbucket provides Basic and OAuth authentication.
 
-### OAuth2 authorization
+### OAuth bearer authorization
 
-You can use `OAuth2Plugin` in order to make authorized requests using version 2 of OAuth protocol.
-
-#### OAuth2 client credentials (_2-legged flow_)
+To access the API with an OAuth access token, you need to attach `Bearer` to the Api instance with your access token.
 
   ```php
-  // @see: https://bitbucket.org/account/user/<username or team>/api
-  $oauth_params = array(
-      'client_id'         => 'aaa',
-      'client_secret'     => 'bbb'
-  );
-
   $bitbucket = new \Bitbucket\API\Api();
-  $bitbucket->addPlugin(
-      new \Bitbucket\API\Http\Plugin\OAuth2Plugin($oauth_params)
+  $bitbucket->setCredentials(
+      new \Http\Message\Authentication\Bearer($accessToken)
   );
 
   $repositories = $bitbucket->api('Repositories');
   $response     = $repositories->all('my_account'); // should include private repositories
   ```
 
-### OAuth1 authorization
-This library comes with a `OAuthPlugin` which will sign all requests for you. All you need to do is to attach the plugin to
-http client with oauth credentials before making a request.
-
-#### OAuth1 1-legged
-  ```php
-  // OAuth 1-legged example
-  // You can create a new consumer at: https://bitbucket.org/account/user/<username or team>/api
-  $oauth_params = array(
-      'oauth_consumer_key'      => 'aaa',
-      'oauth_consumer_secret'   => 'bbb'
-  );
-
-  $user = new Bitbucket\API\User;
-  $user->addPlugin(
-      new \Bitbucket\API\Http\Plugin\OAuthPlugin($oauth_params)
-  );
-
-  // now you can access protected endpoints as consumer owner
-  $response = $user->get();
-  ```
-
 ### Basic authentication
 To use basic authentication, you need to attach `BasicAuth` to the Api instance with your username and a personal access token.
-
-_Please note that is not recommended from a security perspective to use your main account in automated tools and scripts
-and you should really consider switching to [OAuth2](#oauth2-authorization) or [OAuth1](#oauth1-authorization)._
 
   ```php
   $user = new Bitbucket\API\User();


### PR DESCRIPTION
Resolves https://github.com/packagist/bitbucket-api/issues/7